### PR TITLE
fix css効かない問題

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-import sitemap from '@astrojs/sitemap';
 
 import node from '@astrojs/node';
 
@@ -15,7 +14,7 @@ export default defineConfig({
 			}
 		}
 	},
-	integrations: [sitemap(), tailwind()],
+	integrations: [tailwind()],
 	server: { port: 1000, host: "0.0.0.0" },
 	output: 'server',
 	adapter: node({

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
 	"dependencies": {
 		"@astrojs/node": "^5.1.0",
 		"@astrojs/rss": "^2.2.0",
-		"@astrojs/sitemap": "^1.2.0",
 		"@astrojs/tailwind": "^3.1.0",
 		"@tailwindcss/line-clamp": "^0.4.2",
 		"@tryghost/content-api": "^1.11.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@astrojs/node': ^5.1.0
   '@astrojs/rss': ^2.2.0
-  '@astrojs/sitemap': ^1.2.0
   '@astrojs/tailwind': ^3.1.0
   '@tailwindcss/line-clamp': ^0.4.2
   '@tryghost/content-api': ^1.11.6
@@ -24,7 +23,6 @@ specifiers:
 dependencies:
   '@astrojs/node': 5.1.0_astro@2.1.2
   '@astrojs/rss': 2.2.0
-  '@astrojs/sitemap': 1.2.0
   '@astrojs/tailwind': 3.1.0_5fkwwuzubt6borit3q7k7y2k74
   '@tailwindcss/line-clamp': 0.4.2_tailwindcss@3.2.7
   '@tryghost/content-api': 1.11.6
@@ -128,13 +126,6 @@ packages:
     dependencies:
       fast-xml-parser: 4.1.3
       kleur: 4.1.5
-    dev: false
-
-  /@astrojs/sitemap/1.2.0:
-    resolution: {integrity: sha512-v4Esbchc7QcbDilDcZ80BrW29o7SoWnuX80dndH+rE92cpiRwdJw5w1bfI17mtmjlt3NjgFxyjVB93ycD9s66A==}
-    dependencies:
-      sitemap: 7.1.1
-      zod: 3.21.4
     dev: false
 
   /@astrojs/tailwind/3.1.0_5fkwwuzubt6borit3q7k7y2k74:
@@ -849,22 +840,12 @@ packages:
       '@types/unist': 2.0.6
     dev: false
 
-  /@types/node/17.0.45:
-    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-    dev: false
-
   /@types/parse5/6.0.3:
     resolution: {integrity: sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==}
     dev: false
 
   /@types/resolve/1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
-    dev: false
-
-  /@types/sax/1.2.4:
-    resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
-    dependencies:
-      '@types/node': 17.0.45
     dev: false
 
   /@types/semver/7.3.13:
@@ -4024,10 +4005,6 @@ packages:
     dependencies:
       suf-log: 2.5.3
 
-  /sax/1.2.4:
-    resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
-    dev: false
-
   /section-matter/1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
@@ -4108,17 +4085,6 @@ packages:
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: false
-
-  /sitemap/7.1.1:
-    resolution: {integrity: sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==}
-    engines: {node: '>=12.0.0', npm: '>=5.6.0'}
-    hasBin: true
-    dependencies:
-      '@types/node': 17.0.45
-      '@types/sax': 1.2.4
-      arg: 5.0.2
-      sax: 1.2.4
     dev: false
 
   /slash/3.0.0:

--- a/frontend/src/components/atom/footer/CommonFooter.astro
+++ b/frontend/src/components/atom/footer/CommonFooter.astro
@@ -1,7 +1,12 @@
 <footer>
 	<p class="text-center mt-2 mb-6 mx-2 text-sm">copyright usuyuki</p>
 	<div class="flex justify-center flex-wrap">
-		<a href="https://twitter.com/usuyuki26" class="mx-4 flex items-center">
+		<a
+			href="https://twitter.com/usuyuki26"
+			class="mx-4 flex items-center"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
 			<img
 				src="/images/icon/Twitter-social-icons-circle-blue.png"
 				alt="twitter"
@@ -9,12 +14,22 @@
 			/>
 			<p class="ml-2 mt-0">Twitter</p>
 		</a>
-		<a href="https://m5y.usuyuki.net/@usuyuki" class="mx-4 flex items-center">
+		<a
+			href="https://m5y.usuyuki.net/@usuyuki"
+			class="mx-4 flex items-center"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
 			<!-- misskey logoじゃっかん余白多めなので大きく取る -->
 			<img src="/images/icon/misskey-logo.png" alt="misskey" class="w-8 aspect-square" />
 			<p class="ml-2 mt-0">Misskey</p>
 		</a>
-		<a href="https://github.com/usuyuki" class="mx-4 flex items-center">
+		<a
+			href="https://github.com/usuyuki"
+			class="mx-4 flex items-center"
+			target="_blank"
+			rel="noopener noreferrer"
+		>
 			<img src="/images/icon/github-mark.png" alt="github" class="w-6 aspect-square" />
 			<p class="ml-2 mt-0">GitHub</p>
 		</a>

--- a/frontend/src/pages/[slug].astro
+++ b/frontend/src/pages/[slug].astro
@@ -1,8 +1,8 @@
 ---
+import '~/styles/blogContent.css';
 import ArticleLayout from '~/layouts/extends/ArticleLayout.astro';
 import { ghostClient } from '~/libs/ghostClient';
 import iso8601TimeToDate from '~/libs/iso8601TimeToDate';
-import '~/styles/blogContent.css';
 const post = await ghostClient.posts
 	.read({
 		slug: Astro.params.slug,
@@ -29,7 +29,7 @@ const headMeta = {
 <ArticleLayout {...headMeta}>
 	<!-- <img src={post.feature_image} alt={post.title} /> -->
 
-	<h1 class="text-center mb-2">{post.title}</h1>
+	<h2 class="text-center mb-2 text-4xl">{post.title}</h2>
 	<p class="text-center my-2 text-green">
 		{post.published_at.year}年{post.published_at.month}月{post.published_at.day}日
 	</p>
@@ -52,6 +52,6 @@ const headMeta = {
 	}
 	<p class="text-center mb-12">{post.reading_time} 分くらいで読めます！</p>
 	{/* eslint-disable */}
-	<Fragment output:server set:html={post.html} />
+	<div class="blog-content" set:html={post.html} />
 	{/* eslint-enable */}
 </ArticleLayout>

--- a/frontend/src/styles/blogContent.css
+++ b/frontend/src/styles/blogContent.css
@@ -1,45 +1,46 @@
-h1 {
-	font-size: 3rem;
+/* なぜか本番のビルドだとこれらのファイルの後にTailwindが読み込まれて、優先度的に反映されないためクラス指定で行う */
+.blog-content > h1 {
+	font-size: 3rem !important;
 }
-h2 {
-	font-size: 2rem;
+.blog-content > h2 {
+	font-size: 2rem !important;
 }
-h3 {
-	font-size: 1.7rem;
+.blog-content > h3 {
+	font-size: 1.7rem !important;
 }
-p {
-	font-size: 1.2rem;
-	margin-top: 1rem;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	margin-top: 3rem;
-	margin-bottom: 1rem;
-	letter-spacing: 0.025em;
-	line-height: 1.25;
+.blog-content > p {
+	font-size: 1.2rem !important;
+	margin-top: 1rem !important;
 }
 
-figure {
-	margin-top: 1.5rem;
-	margin-bottom: 1rem;
+.blog-content > h1,
+.blog-content > h2,
+.blog-content > h3,
+.blog-content > h4,
+.blog-content > h5,
+.blog-content > h6 {
+	margin-top: 3rem !important;
+	margin-bottom: 1rem !important;
+	letter-spacing: 0.025em !important;
+	line-height: 1.25 !important;
 }
-iframe {
-	width: 90%;
-	aspect-ratio: 16 / 9;
+
+.blog-content > figure {
+	margin-top: 1.5rem !important;
+	margin-bottom: 1rem !important;
 }
-.speakerdeck-iframe {
-	width: 70%;
-	aspect-ratio: 16 / 9;
+.blog-content > iframe {
+	width: 90% !important;
+	aspect-ratio: 16 / 9 !important;
+}
+.blog-content > .speakerdeck-iframe {
+	width: 70% !important;
+	aspect-ratio: 16 / 9 !important;
 }
 
 /* 下記がサイズ無視するので抑える */
-.wp-block-verse,
-.wp-block-preformatted {
-	overflow-x: scroll;
-	padding: 1em 1em;
+.blog-content > .wp-block-verse,
+.blog-content > .wp-block-preformatted {
+	overflow-x: scroll !important;
+	padding: 1em 1em !important;
 }


### PR DESCRIPTION
# 原因
nodeでSSRする時にビルドの順番的に先に内部のCSSを呼んだ後にTailwindを呼ぶようになっているらしく、クラスでなく
```
h1{
font-size:3rem;
}
```
のようにしてもブラウザ側でTailiwindのほうが後に読まれて無視される。

# 解決
コンポーネントごとにCSSを閉じれる良さが吹っ飛んでるが、1つ1つ`.class>h1`のように指定。
Astro内部の
```
<style></style>
```
でやってもだめなので、これはもうどうしようもできない。


# 注意事項
astro devでは生じない
