### PR TITLE
feat Image部分導入

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -1,24 +1,31 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
-
 import node from '@astrojs/node';
+
+import image from "@astrojs/image";
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://blog.usuyuki.net',
-	vite: {
-		resolve: {
-			alias: {
-				// tsconfig.jsonにも定義
-				'~': '/src'
-			}
-		}
-	},
-	integrations: [tailwind()],
-	server: { port: 1000, host: "0.0.0.0" },
-	output: 'server',
-	adapter: node({
-		// middlewareだとファイルをうまくできずFW作る必要あるのでstandaloneで動かす
-		mode: 'standalone'
-	})
+  site: 'https://blog.usuyuki.net',
+  vite: {
+    resolve: {
+      alias: {
+        // tsconfig.jsonにも定義
+        '~': '/src'
+      }
+    }
+  },
+  integrations: [tailwind(), image({
+    serviceEntryPoint: '@astrojs/image/sharp'
+  }
+  )],
+  server: {
+    port: 1000,
+    host: "0.0.0.0"
+  },
+  output: 'server',
+  adapter: node({
+    // middlewareだとファイルをうまくできずFW作る必要あるのでstandaloneで動かす
+    mode: 'standalone'
+  })
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
 		"format": "prettier --write **/*.{css,scss,ts,tsx,astro}"
 	},
 	"dependencies": {
+		"@astrojs/image": "^0.16.0",
 		"@astrojs/node": "^5.1.0",
 		"@astrojs/rss": "^2.2.0",
 		"@astrojs/tailwind": "^3.1.0",
@@ -24,6 +25,7 @@
 		"@tryghost/helpers": "^1.1.76",
 		"astro": "^2.1.2",
 		"image-size": "^1.0.2",
+		"sharp": "^0.31.3",
 		"tailwindcss": "^3.0.24"
 	},
 	"devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@astrojs/image': ^0.16.0
   '@astrojs/node': ^5.1.0
   '@astrojs/rss': ^2.2.0
   '@astrojs/tailwind': ^3.1.0
@@ -17,18 +18,21 @@ specifiers:
   postcss-html: ^1.5.0
   prettier: ^2.8.4
   prettier-plugin-astro: ^0.8.0
+  sharp: ^0.31.3
   tailwindcss: ^3.0.24
   typescript: ^4.9.5
 
 dependencies:
+  '@astrojs/image': 0.16.0_astro@2.1.2+sharp@0.31.3
   '@astrojs/node': 5.1.0_astro@2.1.2
   '@astrojs/rss': 2.2.0
   '@astrojs/tailwind': 3.1.0_5fkwwuzubt6borit3q7k7y2k74
   '@tailwindcss/line-clamp': 0.4.2_tailwindcss@3.2.7
   '@tryghost/content-api': 1.11.6
   '@tryghost/helpers': 1.1.76
-  astro: 2.1.2
+  astro: 2.1.2_sharp@0.31.3
   image-size: 1.0.2
+  sharp: 0.31.3
   tailwindcss: 3.2.7
 
 devDependencies:
@@ -44,6 +48,10 @@ devDependencies:
 
 packages:
 
+  /@altano/tiny-async-pool/1.0.2:
+    resolution: {integrity: sha512-qQzaI0TBUPdpjZ3qo5b2ziQY9MSNpbziH2ZrE5lvtUZL+kn9GwVuVJwoOubaoNkeDB+rqEefnpu1k+oMpOCYiw==}
+    dev: false
+
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
     engines: {node: '>=6.0.0'}
@@ -58,6 +66,25 @@ packages:
 
   /@astrojs/compiler/1.2.0:
     resolution: {integrity: sha512-O8yPCyuq+PU9Fjht2tIW6WzSWiq8qDF1e8uAX2x+SOGFzKqOznp52UlDG2mSf+ekf0Z3R34sb64O7SgX+asTxg==}
+
+  /@astrojs/image/0.16.0_astro@2.1.2+sharp@0.31.3:
+    resolution: {integrity: sha512-9nZSA6/3ucdj5/M774CX0qtPtNZVGJeH6uTL4/4rYJgOZTFfr5CEGNmY9MIyayIYvatvG3VXyRGInLKEo4bXsg==}
+    peerDependencies:
+      astro: ^2.1.0
+      sharp: '>=0.31.0'
+    peerDependenciesMeta:
+      sharp:
+        optional: true
+    dependencies:
+      '@altano/tiny-async-pool': 1.0.2
+      astro: 2.1.2_sharp@0.31.3
+      http-cache-semantics: 4.1.1
+      image-size: 1.0.2
+      kleur: 4.1.5
+      magic-string: 0.27.0
+      mime: 3.0.0
+      sharp: 0.31.3
+    dev: false
 
   /@astrojs/language-server/0.28.3:
     resolution: {integrity: sha512-fPovAX/X46eE2w03jNRMpQ7W9m2mAvNt4Ay65lD9wl1Z5vIQYxlg7Enp9qP225muTr4jSVB5QiLumFJmZMAaVA==}
@@ -83,7 +110,7 @@ packages:
       astro: ^2.1.0
     dependencies:
       '@astrojs/prism': 2.1.0
-      astro: 2.1.2
+      astro: 2.1.2_sharp@0.31.3
       github-slugger: 1.5.0
       image-size: 1.0.2
       import-meta-resolve: 2.2.1
@@ -107,7 +134,7 @@ packages:
       astro: ^2.1.0
     dependencies:
       '@astrojs/webapi': 2.1.0
-      astro: 2.1.2
+      astro: 2.1.2_sharp@0.31.3
       send: 0.18.0
       server-destroy: 1.0.1
     transitivePeerDependencies:
@@ -135,7 +162,7 @@ packages:
       tailwindcss: ^3.0.24
     dependencies:
       '@proload/core': 0.3.3
-      astro: 2.1.2
+      astro: 2.1.2_sharp@0.31.3
       autoprefixer: 10.4.14_postcss@8.4.21
       postcss: 8.4.21
       postcss-load-config: 4.0.1_postcss@8.4.21
@@ -1155,7 +1182,7 @@ packages:
       - supports-color
     dev: true
 
-  /astro/2.1.2:
+  /astro/2.1.2_sharp@0.31.3:
     resolution: {integrity: sha512-qxBIPHfFJhwNOxI2E96XrGrUM6lGkDRkDY8iqEJNFWPGP+t5yY5SWb8H+OdYUGopexy1GGjoY7SYQCzFBkt7iw==}
     engines: {node: '>=16.12.0', npm: '>=6.14.0'}
     hasBin: true
@@ -1206,6 +1233,7 @@ packages:
       rehype: 12.0.1
       semver: 7.3.8
       server-destroy: 1.0.1
+      sharp: 0.31.3
       shiki: 0.11.1
       slash: 4.0.0
       string-width: 5.1.2
@@ -1290,6 +1318,14 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /bl/4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.1
+    dev: false
+
   /bl/5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
     dependencies:
@@ -1334,6 +1370,13 @@ packages:
       electron-to-chromium: 1.4.327
       node-releases: 2.0.10
       update-browserslist-db: 1.0.10_browserslist@4.21.5
+    dev: false
+
+  /buffer/5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
     dev: false
 
   /buffer/6.0.3:
@@ -1428,6 +1471,10 @@ packages:
       fsevents: 2.3.2
     dev: false
 
+  /chownr/1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+    dev: false
+
   /ci-info/3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}
     engines: {node: '>=8'}
@@ -1473,6 +1520,21 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  /color-string/1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+    dev: false
+
+  /color/4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+    dev: false
 
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1554,6 +1616,18 @@ packages:
       character-entities: 2.0.2
     dev: false
 
+  /decompress-response/6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      mimic-response: 3.1.0
+    dev: false
+
+  /deep-extend/0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+    dev: false
+
   /deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -1608,6 +1682,11 @@ packages:
   /destroy/1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: false
+
+  /detect-libc/2.0.1:
+    resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
+    engines: {node: '>=8'}
     dev: false
 
   /detective/5.2.1:
@@ -1720,6 +1799,12 @@ packages:
   /encodeurl/1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
+    dev: false
+
+  /end-of-stream/1.4.4:
+    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    dependencies:
+      once: 1.4.0
     dev: false
 
   /entities/4.4.0:
@@ -2097,6 +2182,11 @@ packages:
       strip-final-newline: 3.0.0
     dev: false
 
+  /expand-template/2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /extend-shallow/2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -2223,6 +2313,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /fs-constants/1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    dev: false
+
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -2277,6 +2371,10 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
     dev: true
+
+  /github-from-package/0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    dev: false
 
   /github-slugger/1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -2510,6 +2608,10 @@ packages:
       entities: 4.4.0
     dev: true
 
+  /http-cache-semantics/4.1.1:
+    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
+    dev: false
+
   /http-errors/2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -2570,6 +2672,10 @@ packages:
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  /ini/1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+    dev: false
+
   /internal-slot/1.0.5:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
@@ -2586,6 +2692,10 @@ packages:
       get-intrinsic: 1.2.0
       is-typed-array: 1.1.10
     dev: true
+
+  /is-arrayish/0.3.2:
+    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+    dev: false
 
   /is-bigint/1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
@@ -3341,6 +3451,11 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /mimic-response/3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+    dev: false
+
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -3349,6 +3464,10 @@ packages:
 
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  /mkdirp-classic/0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: false
 
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -3370,6 +3489,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  /napi-build-utils/1.0.2:
+    resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
+    dev: false
+
   /natural-compare-lite/1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -3382,6 +3505,17 @@ packages:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
     dependencies:
       '@types/nlcst': 1.0.0
+    dev: false
+
+  /node-abi/3.33.0:
+    resolution: {integrity: sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.3.8
+    dev: false
+
+  /node-addon-api/5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
     dev: false
 
   /node-releases/2.0.10:
@@ -3449,7 +3583,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -3708,6 +3841,25 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /prebuild-install/7.1.1:
+    resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      detect-libc: 2.0.1
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 1.0.2
+      node-abi: 3.33.0
+      pump: 3.0.0
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.1
+      tunnel-agent: 0.6.0
+    dev: false
+
   /preferred-pm/3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
     engines: {node: '>=10'}
@@ -3765,6 +3917,13 @@ packages:
     resolution: {integrity: sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==}
     dev: false
 
+  /pump/3.0.0:
+    resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
+    dependencies:
+      end-of-stream: 1.4.4
+      once: 1.4.0
+    dev: false
+
   /punycode/2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -3787,6 +3946,16 @@ packages:
   /range-parser/1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /rc/1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
     dev: false
 
   /read-cache/1.0.0:
@@ -4053,6 +4222,21 @@ packages:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: false
 
+  /sharp/0.31.3:
+    resolution: {integrity: sha512-XcR4+FCLBFKw1bdB+GEhnUNXNXvnt0tDo4WsBsraKymuo/IAuPuCBVAL2wIkUw2r/dwFW5Q5+g66Kwl2dgDFVg==}
+    engines: {node: '>=14.15.0'}
+    requiresBuild: true
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.1
+      node-addon-api: 5.1.0
+      prebuild-install: 7.1.1
+      semver: 7.3.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.1
+      tunnel-agent: 0.6.0
+    dev: false
+
   /shebang-command/2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -4081,6 +4265,24 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: false
+
+  /simple-concat/1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+    dev: false
+
+  /simple-get/4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    dev: false
+
+  /simple-swizzle/0.2.2:
+    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+    dependencies:
+      is-arrayish: 0.3.2
     dev: false
 
   /sisteransi/1.0.5:
@@ -4203,6 +4405,11 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /strip-json-comments/2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4279,6 +4486,26 @@ packages:
       - ts-node
     dev: false
 
+  /tar-fs/2.1.1:
+    resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.0
+      tar-stream: 2.2.0
+    dev: false
+
+  /tar-stream/2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.4
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.1
+    dev: false
+
   /text-table/0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -4349,6 +4576,12 @@ packages:
       tslib: 1.14.1
       typescript: 4.9.5
     dev: true
+
+  /tunnel-agent/0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4701,7 +4934,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/frontend/src/components/atom/SocialIcon.astro
+++ b/frontend/src/components/atom/SocialIcon.astro
@@ -1,0 +1,39 @@
+---
+// import { Image } from '@astrojs/image/components';
+// なぜかnodeではpublicまたはsrc内の画像を入れると読み込みが終わらなくなるので廃止
+---
+
+<div class="flex justify-center flex-wrap">
+	<a
+		href="https://twitter.com/usuyuki26"
+		class="mx-4 flex items-center"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<img
+			src="/images/icon/Twitter-social-icons-circle-blue.png"
+			alt="twitter"
+			class="w-6 aspect-square"
+		/>
+		<p class="ml-2 mt-0">Twitter</p>
+	</a>
+	<a
+		href="https://m5y.usuyuki.net/@usuyuki"
+		class="mx-4 flex items-center"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<!-- misskey logoじゃっかん余白多めなので大きく取る -->
+		<img src="/images/icon/misskey-logo.png" alt="misskey" class="w-8 aspect-square" />
+		<p class="ml-2 mt-0">Misskey</p>
+	</a>
+	<a
+		href="https://github.com/usuyuki"
+		class="mx-4 flex items-center"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<img src="/images/icon/github-mark.png" alt="github" class="w-6 aspect-square" />
+		<p class="ml-2 mt-0">GitHub</p>
+	</a>
+</div>

--- a/frontend/src/components/atom/SocialIconImage.astro_
+++ b/frontend/src/components/atom/SocialIconImage.astro_
@@ -1,0 +1,55 @@
+---
+import { Image } from '@astrojs/image/components';
+import TwitterIcon from '~/assets/icon/Twitter-social-icons-circle-blue.png';
+import MisskeyIcon from '~/assets/icon/misskey-logo.png';
+import GitHubIcon from '~/assets/icon/github-mark.png';
+---
+
+<div class="flex justify-center flex-wrap">
+	<a
+		href="https://twitter.com/usuyuki26"
+		class="mx-4 flex items-center"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<Image
+			src={TwitterIcon}
+			alt="twitter"
+			width={24}
+			aspectRatio="1:1"
+			class="w-6 aspect-square"
+		/>
+		<p class="ml-2 mt-0">Twitter</p>
+	</a>
+	<a
+		href="https://m5y.usuyuki.net/@usuyuki"
+		class="mx-4 flex items-center"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<!-- misskey logoじゃっかん余白多めなので大きく取る -->
+		<Image
+			src={MisskeyIcon}
+			width={24}
+			aspectRatio="1:1"
+			alt="misskey"
+			class="w-8 aspect-square"
+		/>
+		<p class="ml-2 mt-0">Misskey</p>
+	</a>
+	<a
+		href="https://github.com/usuyuki"
+		class="mx-4 flex items-center"
+		target="_blank"
+		rel="noopener noreferrer"
+	>
+		<Image
+			src={GitHubIcon}
+			width={24}
+			aspectRatio="1:1"
+			alt="github"
+			class="w-6 aspect-square"
+		/>
+		<p class="ml-2 mt-0">GitHub</p>
+	</a>
+</div>

--- a/frontend/src/components/atom/footer/CommonFooter.astro
+++ b/frontend/src/components/atom/footer/CommonFooter.astro
@@ -1,39 +1,10 @@
+---
+import SocialIcon from '~/components/atom/SocialIcon.astro';
+---
+
 <footer>
 	<p class="text-center mt-2 mb-6 mx-2 text-sm">copyright usuyuki</p>
-	<div class="flex justify-center flex-wrap">
-		<a
-			href="https://twitter.com/usuyuki26"
-			class="mx-4 flex items-center"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			<img
-				src="/images/icon/Twitter-social-icons-circle-blue.png"
-				alt="twitter"
-				class="w-6 aspect-square"
-			/>
-			<p class="ml-2 mt-0">Twitter</p>
-		</a>
-		<a
-			href="https://m5y.usuyuki.net/@usuyuki"
-			class="mx-4 flex items-center"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			<!-- misskey logoじゃっかん余白多めなので大きく取る -->
-			<img src="/images/icon/misskey-logo.png" alt="misskey" class="w-8 aspect-square" />
-			<p class="ml-2 mt-0">Misskey</p>
-		</a>
-		<a
-			href="https://github.com/usuyuki"
-			class="mx-4 flex items-center"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			<img src="/images/icon/github-mark.png" alt="github" class="w-6 aspect-square" />
-			<p class="ml-2 mt-0">GitHub</p>
-		</a>
-	</div>
+	<SocialIcon />
 </footer>
 <style>
 	footer {

--- a/frontend/src/components/molecule/archive/ArticleArchive.astro
+++ b/frontend/src/components/molecule/archive/ArticleArchive.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from '@astrojs/image/components';
 import SmallMD from '~/components/atom/date/SmallMD.astro';
 import iso8601TimeToDate from '~/libs/iso8601TimeToDate';
 const postsData = Astro.props;
@@ -17,7 +18,15 @@ postsData.posts.map((post: any) => {
 				href={`/${post.slug}`}
 			>
 				<SmallMD month={post.published_at.month} day={post.published_at.day} />
-				<img src={post.feature_image} class="aspect-square h-40 object-cover" />
+				<div class="aspect-square h-40 object-cover">
+					<Image
+						src={post.feature_image}
+						width={500}
+						aspectRatio={1 / 1}
+						format="avif"
+						alt="記事サムネイル"
+					/>
+				</div>
 				<h3 class="text-xl text-black"> {post.title} </h3>
 			</a>
 		))

--- a/frontend/src/components/molecule/index/ArticleArchive.astro
+++ b/frontend/src/components/molecule/index/ArticleArchive.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from '@astrojs/image/components';
 import SmallD from '~/components/atom/date/SmallD.astro';
 import iso8601TimeToDate from '~/libs/iso8601TimeToDate';
 const postsData = Astro.props;
@@ -17,7 +18,15 @@ postsData.posts.map((post: any) => {
 				href={`/${post.slug}`}
 			>
 				<SmallD month={post.published_at.month} day={post.published_at.day} />
-				<img src={post.feature_image} class="aspect-square h-40 object-cover" />
+				<div class="aspect-square h-40 object-cover">
+					<Image
+						src={post.feature_image}
+						width={500}
+						aspectRatio={1 / 1}
+						format="avif"
+						alt="記事サムネイル"
+					/>
+				</div>
 				<h3 class="text-xl text-black"> {post.title} </h3>
 			</a>
 		))

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="../.astro/types.d.ts" />
-/// <reference types="astro/client" />
+/// <reference types="@astrojs/image/client" />
 interface ImportMetaEnv {
 	readonly GHOST_CONTENT_KEY: string;
 	readonly GHOST_API_URL: string;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "astro/tsconfigs/strict",
 	"compilerOptions": {
 		"strictNullChecks": true,
+		"types": ["@astrojs/image/client"],
 		"baseUrl": ".",
 		"paths": {
 			// astro.config.mjsにも定義


### PR DESCRIPTION
トップとかアーカイブでのサムネにImagを適応

記事内はGhostがはくので無理

なぜかローカルの画像はpnpm devで動くけど,nodeで無限ロードに入ったので廃止。
