### PR TITLE
fix: 配列に渡されるインデックスの計算を修正

### DIFF
--- a/frontend/src/components/atom/date/YMDMolecule.astro
+++ b/frontend/src/components/atom/date/YMDMolecule.astro
@@ -27,7 +27,7 @@ const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
 		class="w-20 h-20 rounded-full text-white font-bold bg-red absolute top-2 left-12 flex justify-center items-center"
 	>
 		<p class="text-2xl">
-			{months[props.month + 1]}
+			{months[props.month - 1]}
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
# やったこと
月を数字から英語表記に変換するときに、配列に渡されるインデックスの計算が誤っていたため修正した。

# 備考

# スクリーンショット(任意)
