### PR TITLE
fix なぜか急にviteでエラーになるようになった

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
 			},
 		}),
 	],
+	server: {
+		allowedHosts: ["blog.usuyuki.net"],
+	},
 	test: {
 		globals: true,
 		environment: "jsdom",


### PR DESCRIPTION
# やったこと
```
Blocked request. This host ("blog.usuyuki.net") is not allowed.
To allow this host, add "blog.usuyuki.net" to `server.allowedHosts` in vite.config.js.
```
# 備考

# スクリーンショット(任意)
