### PR TITLE
feat rssで要約表示 & 最大件数を50にする

### DIFF
--- a/frontend/src/libs/articleAggregator.ts
+++ b/frontend/src/libs/articleAggregator.ts
@@ -29,6 +29,7 @@ export function convertGhostToArticle(post: PostOrPage): ArticleArchiveType {
 		published_at: post.published_at || "",
 		feature_image: post.feature_image || undefined,
 		title: post.title || "",
+		excerpt: post.excerpt || undefined,
 		isExternal: false,
 	};
 }

--- a/frontend/src/libs/ghostClient.ts
+++ b/frontend/src/libs/ghostClient.ts
@@ -19,6 +19,7 @@ function convertToArticleArchiveType(post: PostOrPage): ArticleArchiveType {
 		published_at: post.published_at || "",
 		feature_image: post.feature_image || undefined,
 		title: post.title || "",
+		excerpt: post.excerpt || undefined,
 		isExternal: false,
 	};
 }

--- a/frontend/src/types/ArticleArchiveType.ts
+++ b/frontend/src/types/ArticleArchiveType.ts
@@ -9,6 +9,7 @@ export type ArticleArchiveType = {
 	published_at: string | DateType;
 	feature_image?: string;
 	title: string;
+	excerpt?: string; // Ghost記事の要約
 	source?: string; // RSS元のブログ名（Ghostの場合はundefined）
 	isExternal?: boolean; // 外部記事フラグ
 	externalUrl?: string; // 外部記事の場合のURL


### PR DESCRIPTION
# やったこと
close https://github.com/usuyuki/usuyuki_blog_v2/issues/210

# 備考
rssは新着通知の側面が強いので、全部返す必要ないので50にする
# スクリーンショット(任意)
