### PR TITLE
feat タイトルを日本語の文節で改行するようにする

### DIFF
--- a/frontend/src/components/molecule/articleArchive/DArticleArchive.astro
+++ b/frontend/src/components/molecule/articleArchive/DArticleArchive.astro
@@ -49,7 +49,7 @@ posts.forEach((post: ArticleArchiveType) => {
 							)}
 						</div>
 						<h3
-							class="text-xl text-black pt-2 text-wrap-balance text-center"
+							class="text-xl text-black pt-2 text-wrap-balance text-center auto-phrase"
 							transition:name={'title-' + post.slug}
 						>
 							{post.title}

--- a/frontend/src/components/molecule/articleArchive/MDArticleArchive.astro
+++ b/frontend/src/components/molecule/articleArchive/MDArticleArchive.astro
@@ -72,7 +72,7 @@ posts.forEach((post: ArticleArchiveType) => {
 							)}
 						</div>
 						<h3
-							class="text-xl text-black pt-2 text-wrap-balance text-center"
+							class="text-xl text-black pt-2 text-wrap-balance text-center auto-phrase"
 							transition:name={'title-' + post.slug}
 						>
 							{post.title}

--- a/frontend/src/components/molecule/articleArchive/YMDArticleArchive.astro
+++ b/frontend/src/components/molecule/articleArchive/YMDArticleArchive.astro
@@ -53,7 +53,7 @@ posts?.forEach((post: ArticleArchiveType) => {
 							)}
 						</div>
 						<h3
-							class="text-xl text-black pt-2 text-wrap-balance text-center"
+							class="text-xl text-black pt-2 text-wrap-balance text-center auto-phrase"
 							transition:name={'title-' + contextPrefix + post.slug}
 						>
 							{post.title}

--- a/frontend/src/pages/[slug].astro
+++ b/frontend/src/pages/[slug].astro
@@ -92,7 +92,7 @@ const isWpArticle = judgeWpArticle(post.html || "");
 		</div>
 		<div class="w-full md:w-3/5">
 			<h2
-				class="text-center mb-2 text-4xl text-wrap-balance"
+				class="text-center mb-2 text-4xl text-wrap-balance auto-phrase"
 				transition:name={'title-' + post.slug}
 			>
 				{post.title}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -55,7 +55,6 @@ h6 {
 	font-weight: bold;
 	font-family: var(--font-family-main);
 }
-
 main {
 	padding: 1rem;
 	max-width: var(--main-max-width);
@@ -73,4 +72,7 @@ a {
 /* text-wrap: balance; Chrome114から追加、今のところはChromeのみだけど適応されなくてマイナスが少ないので入れる */
 .text-wrap-balance {
 	text-wrap: balance;
+}
+.auto-phrase {
+	word-break: auto-phrase;
 }

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1,9 +1,5 @@
 @import "tailwindcss";
 
-@utility auto-phrase {
-	word-break: auto-phrase;
-}
-
 @theme {
 	--color-white: #fcf7f4;
 	--color-black: #540610;

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+@utility auto-phrase {
+	word-break: auto-phrase;
+}
+
 @theme {
 	--color-white: #fcf7f4;
 	--color-black: #540610;


### PR DESCRIPTION
# やったこと
<img width="1659" height="830" alt="image" src="https://github.com/user-attachments/assets/0f0803c5-c426-43a8-8250-69c54fc7ee37" />


昔やったけど戻していた。
本文は改行するとキモいけど、タイトルは改行したほうが見やすい
# 備考

# スクリーンショット(任意)
