### PR TITLE
fix 攻撃対策で入れてた長い文字除外が、たまに引っかかっている問題の修正

### DIFF
--- a/frontend/src/libs/validation/__tests__/isSlug.test.ts
+++ b/frontend/src/libs/validation/__tests__/isSlug.test.ts
@@ -2,9 +2,18 @@ import { describe, it, expect } from "vitest";
 import { isSlug } from "../isSlug";
 
 describe("isSlug", () => {
-  it("should respect 100 character limit", () => {
-    expect(isSlug("a".repeat(100))).toBe(true);
-    expect(isSlug("a".repeat(101))).toBe(false);
+  it("should respect 191 character limit", () => {
+    expect(isSlug("a".repeat(191))).toBe(true);
+    expect(isSlug("a".repeat(192))).toBe(false);
+  });
+
+  it("should accept long Japanese-encoded slugs", () => {
+    // Ghost CMS が日本語タイトルを UTF-8 hex に変換した例（141文字）
+    expect(
+      isSlug(
+        "vtuber-e3-82-92-e8-a6-8b-e3-81-a6-e4-ba-ba-e7-94-9f-e3-81-ab-e5-bd-a9-e3-82-8a-e3-81-8c-e7-94-9f-e3-81-be-e3-82-8c-e3-81-be-e3-81-97-e3-81-9f",
+      ),
+    ).toBe(true);
   });
 
   it("should accept valid slugs", () => {

--- a/frontend/src/libs/validation/isSlug.ts
+++ b/frontend/src/libs/validation/isSlug.ts
@@ -1,13 +1,15 @@
 /**
- * 記事・タグスラッグのバリデーション（100文字制限）
+ * 記事・タグスラッグのバリデーション（191文字制限）
  * 英数字・ハイフン・アンダースコアのみを許可
+ * Ghost CMS が日本語タイトルを UTF-8 バイトのハイフン区切り hex に変換するため、
+ * 日本語スラッグは100文字を大幅に超える場合がある（例: 141文字）
  */
 export function isSlug(slug: string | undefined): boolean {
   return (
     !!slug &&
     typeof slug === "string" &&
     slug.trim() !== "" &&
-    slug.length <= 100 &&
+    slug.length <= 191 &&
     /^[a-zA-Z0-9\-_]+$/.test(slug) &&
     !slug.startsWith("_") &&
     !["assets", "api", "admin", "undefined", "null"].includes(


### PR DESCRIPTION
# やったこと
https://blog.usuyuki.net/vtuber-e3-82-92-e8-a6-8b-e3-81-a6-e4-ba-ba-e7-94-9f-e3-81-ab-e5-bd-a9-e3-82-8a-e3-81-8c-e7-94-9f-e3-81-be-e3-82-8c-e3-81-be-e3-81-97-e3-81-9f

とか見れなくなってたので見れるようにする。そもそもslugが良くないが、wordpress自体から持ってきたやつなのでやむなし、、
# 備考

# スクリーンショット(任意)
