### PR TITLE
Feat Recent Articlesにもっと見るを出す ＆ バグ修正

### DIFF
--- a/frontend/src/components/atom/head/CommonHead.astro
+++ b/frontend/src/components/atom/head/CommonHead.astro
@@ -55,3 +55,14 @@ const pageTitle = `${title} | ${SITE_TITLE}`;
 <meta name="twitter:image" content={ogImage} />
 
 <ClientRouter />
+
+<script>
+  // ClientRouter (View Transitions) でページ遷移後もTwitterウィジェットを再初期化する
+  document.addEventListener("astro:page-load", () => {
+    // twttrはTwitterウィジェットがグローバルに登録する外部APIなので型定義がない
+    const twttr = (window as unknown as { twttr?: { widgets?: { load: () => void } } }).twttr;
+    if (twttr?.widgets) {
+      twttr.widgets.load();
+    }
+  });
+</script>

--- a/frontend/src/components/molecule/articleArchive/YMDArticleArchive.astro
+++ b/frontend/src/components/molecule/articleArchive/YMDArticleArchive.astro
@@ -69,14 +69,14 @@ posts?.forEach((post: ArticleArchiveType) => {
 			<div class="w-1/2 md:w-1/3 lg:w-1/4 xl:w-1/5 mb-12">
 				<div class="flex justify-center items-center h-full">
 					<a
-						class="hover:shadow-xl p-2 block rounded-xl duration-300 border-2 border-dashed border-gray-300 hover:border-gray-400 aspect-square w-1/2"
+						class="hover:shadow-xl p-2 block rounded-xl duration-300 border-2 border-dashed border-gray-300 hover:border-gray-400 aspect-square w-3/4 md:w-1/2"
 						href="/archive"
 					>
 						<div class="group flex justify-center items-center flex-col h-full gap-3 text-gray-500 hover:text-gray-700">
 							<div class="more-arrow-container">
 								<span class="text-4xl more-arrow">&rarr;</span>
 							</div>
-							<span class="text-base font-medium">もっと見る</span>
+							<span class="text-base font-medium whitespace-nowrap">もっと見る</span>
 						</div>
 					</a>
 				</div>

--- a/frontend/src/components/molecule/articleArchive/YMDArticleArchive.astro
+++ b/frontend/src/components/molecule/articleArchive/YMDArticleArchive.astro
@@ -8,8 +8,9 @@ import type { ArticleArchiveType } from "~/types/ArticleArchiveType";
 interface Props {
   posts: ArticleArchiveType[];
   contextPrefix?: string;
+  showMore?: boolean;
 }
-const { posts, contextPrefix = "" } = Astro.props;
+const { posts, contextPrefix = "", showMore = false } = Astro.props;
 //日付の変換
 posts?.forEach((post: ArticleArchiveType) => {
   if (typeof post.published_at === "string") {
@@ -18,7 +19,7 @@ posts?.forEach((post: ArticleArchiveType) => {
 });
 ---
 
-<div class="flex flex-wrap items-stretch">
+<div class="flex flex-wrap items-stretch justify-center">
 	{
 		posts?.map((post: ArticleArchiveType, index: number) => (
 			<div class="w-1/2 md:w-1/3 lg:w-1/4 xl:w-1/5 mb-12">
@@ -63,4 +64,110 @@ posts?.forEach((post: ArticleArchiveType) => {
 			</div>
 		))
 	}
+	{
+		showMore && (
+			<div class="w-1/2 md:w-1/3 lg:w-1/4 xl:w-1/5 mb-12">
+				<div class="flex justify-center items-center h-full">
+					<a
+						class="hover:shadow-xl p-2 block rounded-xl duration-300 border-2 border-dashed border-gray-300 hover:border-gray-400 aspect-square w-1/2"
+						href="/archive"
+					>
+						<div class="group flex justify-center items-center flex-col h-full gap-3 text-gray-500 hover:text-gray-700">
+							<div class="more-arrow-container">
+								<span class="text-4xl more-arrow">&rarr;</span>
+							</div>
+							<span class="text-base font-medium">もっと見る</span>
+						</div>
+					</a>
+				</div>
+			</div>
+		)
+	}
 </div>
+
+<style is:global>
+	.more-arrow-container {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 3rem;
+		height: 3rem;
+	}
+
+	.more-arrow {
+		display: inline-block;
+		transition: transform 0.15s ease-out;
+		position: relative;
+		z-index: 1;
+	}
+
+	.group:hover .more-arrow {
+		transform: translateX(5px);
+	}
+
+	.speed-particle {
+		position: absolute;
+		height: 3px;
+		border-radius: 2px;
+		background: currentColor;
+		pointer-events: none;
+		transform-origin: left center;
+		z-index: 0;
+	}
+</style>
+
+<script>
+	function spawnParticlesBurst(container: HTMLElement, count = 4) {
+		const w = container.offsetWidth;
+		const h = container.offsetHeight;
+
+		for (let i = 0; i < count; i++) {
+			const p = document.createElement("span");
+			p.className = "speed-particle";
+
+			// 右寄りから出発して左へ流れる（矢印の後ろに残るスピードライン）
+			const left  = w * 0.45 + Math.random() * w * 0.45;
+			const top   = h * 0.1  + Math.random() * h * 0.8;
+			const txEnd = -(28 + Math.random() * 40);
+			const ty    = (Math.random() - 0.5) * 10;
+			const width = 8 + Math.random() * 22;
+			const delay = Math.random() * 80;
+			const dur   = 550 + Math.random() * 550;
+
+			p.style.cssText = `left:${left}px;top:${top}px;width:${width}px;`;
+			container.appendChild(p);
+
+			const anim = p.animate(
+				[
+					{ opacity: 0.9, transform: `translate(0px, ${ty}px) scaleX(0.3)` },
+					{ opacity: 0.6, transform: `translate(${txEnd * 0.4}px, ${ty}px) scaleX(0.8)`, offset: 0.4 },
+					{ opacity: 0,   transform: `translate(${txEnd}px, ${ty}px) scaleX(1)` },
+				],
+				{ duration: dur, delay, fill: "both", easing: "ease-out" },
+			);
+			anim.onfinish = () => p.remove();
+		}
+	}
+
+	function initMoreArrow() {
+		document.querySelectorAll<HTMLElement>(".more-arrow-container").forEach((el) => {
+			let intervalId: ReturnType<typeof setInterval> | null = null;
+			const card = el.closest("a") ?? el;
+
+			card.addEventListener("mouseenter", () => {
+				spawnParticlesBurst(el, 6);
+				intervalId = setInterval(() => spawnParticlesBurst(el, 3), 130);
+			});
+			card.addEventListener("mouseleave", () => {
+				if (intervalId !== null) {
+					clearInterval(intervalId);
+					intervalId = null;
+				}
+			});
+		});
+	}
+
+	document.addEventListener("astro:page-load", initMoreArrow);
+	initMoreArrow();
+</script>

--- a/frontend/src/layouts/extends/ArticleLayout.astro
+++ b/frontend/src/layouts/extends/ArticleLayout.astro
@@ -35,7 +35,7 @@ const recentArticlesWithFormattedDate = recentArticles.map(
 	<div class="flex justify-center flex-wrap">
 		<div class="w-full">
 			<h2 class="text-2xl font-bold mb-12">Recent Articles</h2>
-			<YMDArticleArchive posts={recentArticlesWithFormattedDate} contextPrefix="recent-" />
+			<YMDArticleArchive posts={recentArticlesWithFormattedDate} contextPrefix="recent-" showMore={true} />
 		</div>
 
 		<div class="w-full md:w-1/2">


### PR DESCRIPTION
# やったこと
コミットの通り。

もっと見るは、ヘッダーがリンクというweb前提をベースにしすぎてるので、動線作りたいので
# 備考

# スクリーンショット(任意)
<img width="550" height="646" alt="image" src="https://github.com/user-attachments/assets/e20b98f2-882e-4f59-a6de-c1c08cf56dec" />

<img width="1335" height="599" alt="スクリーンショット 2026-06-01 0 30 24" src="https://github.com/user-attachments/assets/fd49881e-ea4f-4f3c-970d-b7a22ad33f9c" />

<img width="175" height="167" alt="image" src="https://github.com/user-attachments/assets/43c5d64b-2e3a-4d93-adc2-f7b5c31f1ebb" />
